### PR TITLE
fix(generator): strip inline comments when parsing colors.toml

### DIFF
--- a/omazed-generator.sh
+++ b/omazed-generator.sh
@@ -376,10 +376,19 @@ parse_colors_toml() {
         if [[ -z "$key" || "$key" == \#* ]]; then
             continue
         fi
-        value=${value%\"}
-        value=${value#\"}
-        value=${value%\'}
-        value=${value#\'}
+        # Strip surrounding quotes and any inline comment. TOML allows
+        # `key = "value"  # comment`, and quoted values legitimately contain
+        # '#' (hex colors), so '#' only starts a comment outside the quotes.
+        if [[ "$value" == \"* ]]; then
+            value=${value#\"}
+            value=${value%%\"*}
+        elif [[ "$value" == \'* ]]; then
+            value=${value#\'}
+            value=${value%%\'*}
+        else
+            value=${value%%[[:space:]]\#*}
+            value=${value%"${value##*[![:space:]]}"}
+        fi
 
         case "$key" in
             # Shared keys (both v3 and v4)


### PR DESCRIPTION
## Problem

A theme whose `colors.toml` uses a trailing inline comment produces an **invalid** `~/.config/zed/themes/omazed.json`. Zed rejects the malformed theme and silently falls back to One Dark, so from the user's side it looks like omazed simply did nothing — no error, no log, just the wrong theme.

`parse_colors_toml()` splits each line on `=` and then strips a single quote from each end of the value:

```bash
value=${value%\"}
value=${value#\"}
```

That never detects where the value actually ended, so for

```toml
background = "#1a1b26"   # Default background for terminals
```

`value` becomes `#1a1b26"   # Default background for terminals`, and the template interpolates the whole thing:

```json
"background": "#1a1b26"   # Default background for terminals",
```

Inline comments are valid TOML, so this is a parser bug rather than a bad theme.

## Reproduce

Any stock theme plus a single comment is enough — nothing community-specific about it:

```bash
sed '0,/^background =/s/$/   # inline comment/' \
  /usr/share/omarchy/themes/tokyo-night/colors.toml > /tmp/repro.toml
./omazed-generator.sh /tmp/repro.toml /tmp/out ./omazed-theme.tpl dark
python3 -c "import json;json.load(open('/tmp/out/omazed.json'))"
# json.decoder.JSONDecodeError: Expecting ',' delimiter: line 10 column 35
```

## Fix

Take the text *between* the quotes rather than trimming one character off each end. The comment falls away as a consequence, and a `#` inside the quotes is preserved so hex colors are unaffected. The unquoted branch trims a ` #…` suffix for bare values.

## Verification

Generated a theme from every `colors.toml` on my machine — 22 stock Omarchy themes and 54 community themes installed via `omarchy theme install` — patched vs unpatched at the same commit:

| | before | after |
|---|---|---|
| Valid JSON | 70 / 76 | **76 / 76** |
| Invalid JSON | 6 | **0** |
| Byte-identical output | — | 70 themes |
| Output changed | — | only the 6 broken ones |

The 70 themes that already worked produce **byte-identical** output, so no theme changes appearance and the WCAG contrast work in 803f696 is untouched.

Themes that were broken: `biscuit-de-mar-dark`, `black_arch`, `catppu_mocha`, `snow_black`, `space-monkey`, `x-1632`. No stock theme is affected, which is probably why this went unnoticed for a while — it only bites on themes whose authors comment their palettes.

`bash -n` clean; no change to the parser's interface or to any other function.
